### PR TITLE
Formatting Contributions Page

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -20,12 +20,12 @@ Replace the first row with your contribution.
 
 | Week #       | Contribution (Link)  | Type  | Description |
 |---|:---|:---|:---|
-|  2   | https://github.com/nyu-ossd-s19/tojimjiang-weekly/issues/2  | blog    |   I opened an issue about a broken link    |
-|  2   |  https://github.com/nyu-ossd-s19/yc2311-weekly/issues/1   |  blog   |   I opened an issue about a broken image   |
-|  2   |  https://github.com/nyu-ossd-s19/screen-cracker-team-7  |    browser add-on  |   I helped to create a browser extension that cracks your screen   |
-|  3  | https://github.com/nyu-ossd-s19/tabi-clock/pull/11 | browser add-on | I helped another team to tweak their browser extension so that it worked responsively and faded in the way that they wanted it to |
-| 3 | https://github.com/nyu-ossd-s19/Maya_Deanna-workflow | class activity | We worked on an in class git workflow activity |
-|  5  | https://github.com/nyu-ossd-s19/gatsby/commit/8d148a5209d36e273c49d5ede9f7db90fe7946fa | project | I created a general structure for solving a claimed bug |
-| 5 | https://github.com/nyu-ossd-s19/gatsby/issues/1 | project | I proposed a possible solution for creating a cross-platform solution to the claimed bug |
-| 6 | https://github.com/nyu-ossd-s19/gatsby/commit/938a0b0b0243d2a3ec8da6c558f0714e4f9ec8e6 | project | I changed the way we were checking against the root directory to use the path's native root property |
-| 6 | https://github.com/gatsbyjs/gatsby/pull/13096 | project | I opened a pull request for the bug that we fixed | 
+|  2   | [tojimjiang-weekly](https://github.com/nyu-ossd-s19/tojimjiang-weekly/issues/2)  | blog    |   I opened an issue about a broken link    |
+|  2   |  [yc2311-weekly](https://github.com/nyu-ossd-s19/yc2311-weekly/issues/1)   |  blog   |   I opened an issue about a broken image   |
+|  2   |  [screen-cracker-team-7](https://github.com/nyu-ossd-s19/screen-cracker-team-7)  |    browser add-on  |   I helped to create a browser extension that cracks your screen   |
+|  3  | [tabi-clock](https://github.com/nyu-ossd-s19/tabi-clock/pull/11) | browser add-on | I helped another team to tweak their browser extension so that it worked responsively and faded in the way that they wanted it to |
+| 3 | [Maya_Deanna-workflow](https://github.com/nyu-ossd-s19/Maya_Deanna-workflow) | class activity | We worked on an in class git workflow activity |
+|  5  | [gatsby commit](https://github.com/nyu-ossd-s19/gatsby/commit/8d148a5209d36e273c49d5ede9f7db90fe7946fa) | project | I created a general structure for solving a claimed bug |
+| 5 | [gatsby issue](https://github.com/nyu-ossd-s19/gatsby/issues/1) | project | I proposed a possible solution for creating a cross-platform solution to the claimed bug |
+| 6 | [gatsby commit](https://github.com/nyu-ossd-s19/gatsby/commit/938a0b0b0243d2a3ec8da6c558f0714e4f9ec8e6) | project | I changed the way we were checking against the root directory to use the path's native root property |
+| 6 | [gatsby pull request](https://github.com/gatsbyjs/gatsby/pull/13096) | project | I opened a pull request for the bug that we fixed | 


### PR DESCRIPTION
The contributions link was bleeding outside of the page wrapper. I fixed this by making the links hyperlink so the column wouldn't be stretched out.

Before:
<img width="500" alt="Screen Shot 2019-04-15 at 3 06 45 PM" src="https://user-images.githubusercontent.com/2825071/56158750-f01ef200-5f90-11e9-9434-384e92b31dae.png">

After:
<img width="500" alt="Screen Shot 2019-04-15 at 3 11 01 PM" src="https://user-images.githubusercontent.com/2825071/56158755-f319e280-5f90-11e9-97f7-c17630fbee19.png">
